### PR TITLE
New test for an edge case

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -115,5 +115,10 @@ TESTS = {
             "answer": False,
             "common": "ab"
         },
+        {
+            "input": ["a", "abcd"],
+            "answer": False,
+            "common": "a"
+        },
     ]
 }


### PR DESCRIPTION
Following incorrect solution from [this forum post](https://checkio.org/forum/post/9571/not-sufficient-tests/#comment-42256) passes all other test cases. It does not check whether `second_word` contains  any letters not present in `first_word`. I added a new test that makes that incorrect function to fail.

```
def verify_anagrams(first_word, second_word):
    first = first_word.lower()
    second = second_word.lower()
    for c in first:
        if c.isspace() or (not c.isalpha()):
            continue
        if first.count(c) != second.count(c):
            return False
    return True
```
